### PR TITLE
Add RX related params to DeviceProfile resource. 

### DIFF
--- a/aws-iotwireless-deviceprofile/aws-iotwireless-deviceprofile.json
+++ b/aws-iotwireless-deviceprofile/aws-iotwireless-deviceprofile.json
@@ -46,6 +46,33 @@
           "type": "string",
           "maxLength": 64
         },
+        "RxDelay1": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 15
+        },
+        "RxDrOffset1": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 7
+        },
+        "RxFreq2": {
+          "type": "integer",
+          "minimum": 1000000,
+          "maximum": 16700000
+        },
+        "RxDataRate2": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 15
+        },
+        "FactoryPresetFreqsList": {
+          "type": "array",
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/FactoryPresetFreq"
+          }
+        },
         "MaxEirp": {
           "type": "integer",
           "minimum": 0,
@@ -83,6 +110,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "FactoryPresetFreq": {
+      "type": "integer",
+      "minimum": 1000000,
+      "maximum": 16700000
     }
   },
   "properties": {

--- a/aws-iotwireless-deviceprofile/inputs/inputs_1_create.json
+++ b/aws-iotwireless-deviceprofile/inputs/inputs_1_create.json
@@ -13,6 +13,14 @@
     "MaxDutyCycle": 0,
     "SupportsJoin": true,
     "RfRegion": "US915",
+    "RxDelay1": 0,
+    "RxDrOffset1": 0,
+    "RxFreq2": 1000000,
+    "RxDataRate2": 0,
+    "FactoryPresetFreqsList": [
+      1000000,
+      16700000
+    ],
     "Supports32BitFCnt": true
   },
   "Tags": [

--- a/aws-iotwireless-deviceprofile/inputs/inputs_1_update.json
+++ b/aws-iotwireless-deviceprofile/inputs/inputs_1_update.json
@@ -1,4 +1,0 @@
-{
-  "Name": "Test Device Profile Update",
-  "Id": "455fe5cb-c6bb-4cab-a917-67df704a119b"
-}

--- a/aws-iotwireless-deviceprofile/src/main/java/software/amazon/iotwireless/deviceprofile/Translator.java
+++ b/aws-iotwireless-deviceprofile/src/main/java/software/amazon/iotwireless/deviceprofile/Translator.java
@@ -47,6 +47,11 @@ public class Translator {
         newProfile.setSupportsJoin(profile.supportsJoin());
         newProfile.setRfRegion(profile.rfRegion());
         newProfile.setSupports32BitFCnt(profile.supports32BitFCnt());
+        newProfile.setRxDelay1(profile.rxDelay1());
+        newProfile.setRxDrOffset1(profile.rxDrOffset1());
+        newProfile.setRxDataRate2(profile.rxDataRate2());
+        newProfile.setRxFreq2(profile.rxFreq2());
+        newProfile.setFactoryPresetFreqsList(profile.factoryPresetFreqsList());
         return newProfile;
     }
 
@@ -71,6 +76,11 @@ public class Translator {
                 .supportsJoin(gateway.getSupportsJoin())
                 .rfRegion(gateway.getRfRegion())
                 .supports32BitFCnt(gateway.getSupports32BitFCnt())
+                .rxDelay1(gateway.getRxDelay1())
+                .rxDrOffset1(gateway.getRxDrOffset1())
+                .rxFreq2(gateway.getRxFreq2())
+                .rxDataRate2(gateway.getRxDataRate2())
+                .factoryPresetFreqsList(gateway.getFactoryPresetFreqsList())
                 .build();
     }
 

--- a/aws-iotwireless-deviceprofile/src/test/java/software/amazon/iotwireless/deviceprofile/AbstractTestBase.java
+++ b/aws-iotwireless-deviceprofile/src/test/java/software/amazon/iotwireless/deviceprofile/AbstractTestBase.java
@@ -1,6 +1,7 @@
 package software.amazon.iotwireless.deviceprofile;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
@@ -42,6 +43,9 @@ public class AbstractTestBase {
   protected static final CallbackContext TEST_CALLBACK;
   protected static final ResourceHandlerRequest<ResourceModel> TEST_REQUEST;
   protected static final LoggerProxy logger;
+  protected static final String TEST_REG_PARAMS_REVISION;
+  protected static final String TEST_MAC_VERSION;
+  protected static final String TEST_RFREGION;
 
   static {
     MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -60,6 +64,9 @@ public class AbstractTestBase {
     TEST_LAST_UPLINK_RECEIVED_AT = "2020-09-24T00:52:52.802771964Z";
     TEST_APP_EUI = "test app eui";
     TEST_APP_KEY = "test app key";
+    TEST_REG_PARAMS_REVISION = "test reg params revision";
+    TEST_MAC_VERSION= "testversion";
+    TEST_RFREGION = "testrfregion";
 
     TEST_TAGS = new HashSet<software.amazon.iotwireless.deviceprofile.Tag>();
     TEST_TAG = new software.amazon.iotwireless.deviceprofile.Tag();
@@ -70,10 +77,25 @@ public class AbstractTestBase {
     TEST_LORA_CREATE = new software.amazon.iotwireless.deviceprofile.LoRaWANDeviceProfile();
     TEST_LORA_CREATE.setSupportsClassB(true);
 
-    //TODO: include more of the fields
     TEST_LORAWAN = software.amazon.awssdk.services.iotwireless.model.LoRaWANDeviceProfile.builder()
             .supportsClassB(true)
             .classBTimeout(1)
+            .pingSlotPeriod(256)
+            .pingSlotDr(0)
+            .pingSlotFreq(8000000)
+            .supportsClassC(true)
+            .macVersion(TEST_MAC_VERSION)
+            .regParamsRevision(TEST_REG_PARAMS_REVISION)
+            .maxEirp(0)
+            .maxDutyCycle(0)
+            .supportsJoin(true)
+            .rfRegion(TEST_RFREGION)
+            .rxDelay1(0)
+            .rxDrOffset1(0)
+            .rxFreq2(1000000)
+            .rxDataRate2(0)
+            .factoryPresetFreqsList(new ArrayList<Integer>(Arrays.asList(100000,1100000)))
+            .supports32BitFCnt(true)
             .build();
 
     TEST_CREATE_RESOURCE_MODEL = ResourceModel.builder()


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1227

*Description of changes:*
Add RX related params to DeviceProfile resource. 
Properties include: 

- RxDelay1: Integer
- RxDrOffset1: Integer
- RxDataRate2: Integer
- RxFreq2: Integer
- FactoryPresetFreqsList: List of Integers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
