### PR TITLE
Fix Lorawan device DevEui pattern

### DIFF
--- a/aws-iotwireless-wirelessdevice/aws-iotwireless-wirelessdevice.json
+++ b/aws-iotwireless-wirelessdevice/aws-iotwireless-wirelessdevice.json
@@ -130,7 +130,7 @@
       "properties": {
         "DevEui": {
           "type": "string",
-          "pattern": "[a-f0-9]{16}"
+          "pattern": "[a-fA-F0-9]{16}"
         },
         "DeviceProfileId": {
           "type": "string",


### PR DESCRIPTION
Fix Lorawan device DevEui pattern to allow majuscule characters

*Issue #, if available:*

*Description of changes:*
Change the pattern to `[a-fA-F0-9]{16}`as supported by the API : [LoRaWANDevice:: DevEui](https://docs.aws.amazon.com/iot-wireless/2020-11-22/apireference/API_LoRaWANDevice.html#iotwireless-Type-LoRaWANDevice-DevEui) in order to avoid CloudFormation error when deploying devices with majuscules in the DevEui value. 

Currently I got the following error `Properties validation failed for resource IotWireless70B3D547501316B6 with message: #/LoRaWAN: #: only 1 subschema matches out of 2 #/LoRaWAN/DevEui: failed validation constraint for keyword [pattern]` when I deploy devices using CDK that contain device with majuscules in the DevEui but I am able to instantiate the device using the console and the same DevEui as it is supported by the API. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
